### PR TITLE
Add option to validate requests

### DIFF
--- a/src/Middleware/ValidationMiddleware.php
+++ b/src/Middleware/ValidationMiddleware.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mw\Psr7Validation\Middleware;
 
+use Mw\Psr7Validation\Validator\RequestValidatorInterface;
 use Mw\Psr7Validation\Validator\ValidationResult;
 use Mw\Psr7Validation\Validator\ValidatorInterface;
 use Psr\Http\Message\MessageInterface;
@@ -47,6 +48,10 @@ class ValidationMiddleware
     {
         $json = $request->getParsedBody();
         $validationResult = new ValidationResult();
+
+        if ($this->validator instanceof RequestValidatorInterface) {
+            $this->validator->validateRequest($request, $validationResult);
+        }
 
         $this->validator->validateJson($json, $validationResult);
 

--- a/src/Validator/CombinedValidator.php
+++ b/src/Validator/CombinedValidator.php
@@ -1,13 +1,15 @@
 <?php
 namespace Mw\Psr7Validation\Validator;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 /**
  * Validator aggregator that executes multiple validators
  *
  * @package    Mw\Psr7Validation
  * @subpackage Validator
  */
-class CombinedValidator implements ValidatorInterface
+class CombinedValidator implements RequestValidatorInterface
 {
 
     /** @var ValidatorInterface[] */
@@ -21,6 +23,21 @@ class CombinedValidator implements ValidatorInterface
     public function __construct(ValidatorInterface ...$validatorInterfaces)
     {
         $this->validatorInterfaces = $validatorInterfaces;
+    }
+
+    /**
+     * Validates the HTTP request itself
+     *
+     * @param ServerRequestInterface $request The HTTP request
+     * @param ValidationResult       $result  The result object in which to store validation results
+     */
+    public function validateRequest(ServerRequestInterface $request, ValidationResult $result)
+    {
+        foreach ($this->validatorInterfaces as $validator) {
+            if ($validator instanceof RequestValidatorInterface) {
+                $validator->validateRequest($request, $result);
+            }
+        }
     }
 
     /**

--- a/src/Validator/RequestValidatorInterface.php
+++ b/src/Validator/RequestValidatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+namespace Mw\Psr7Validation\Validator;
+
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface RequestValidatorInterface extends ValidatorInterface
+{
+
+    /**
+     * Validates a JSON object
+     *
+     * @param ServerRequestInterface $request The request to validate
+     * @param ValidationResult       $result  The result object in which to store validation result
+     * @return
+     */
+    public function validateRequest(ServerRequestInterface $request, ValidationResult $result);
+
+}


### PR DESCRIPTION
Currently, the `ValidatorInterface` does not offer access to the actual HTTP request.

This PR introduces a new `RequestValidatorInterface` that also accepts the HTTP request as parameter and can use it in its validation process.
